### PR TITLE
Upgrade dependencies fix build issues

### DIFF
--- a/Content/Web/.babelrc
+++ b/Content/Web/.babelrc
@@ -1,5 +1,3 @@
 {
-    "presets": [
-      "./node_modules/@dolittle/build/.babelrc.js"
-    ]
+  "extends": "./node_modules/@dolittle/build/.babelrc"
 }

--- a/Content/Web/README.md
+++ b/Content/Web/README.md
@@ -1,0 +1,1 @@
+> __Note__: There are currently some issues with dependencies while using `npm`. So for the time being, please use `yarn` instead [see here](https://yarnpkg.com/en/).

--- a/Content/Web/package.json
+++ b/Content/Web/package.json
@@ -12,8 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@dolittle/build": "1.0.0",
-    "@dolittle/build.aurelia": "1.1.0",
+    "@dolittle/build.aurelia": "3.2.1",
     "@dolittle/styles": "^2.9.5",
     "webpack": "^4.26.0",
     "webpack-cli": "^3.1.2",


### PR DESCRIPTION
Upgraded `@dolittle/build.aurelia`, and fixed syntax of `.babelrc`.

Also added a note in the README to use `yarn` in stead of `npm`. Not sure if it's visible enough, but I guess people might look at the README if the build fails.