### PR TITLE
Fix Web boilerplates

### DIFF
--- a/Content/Web/Features/main.js
+++ b/Content/Web/Features/main.js
@@ -1,6 +1,5 @@
 import environment from './environment';
 import { PLATFORM } from 'aurelia-pal';
-import 'babel-polyfill';
 import * as Bluebird from 'bluebird';
 
 // remove out if you don't want a Promise polyfill (remove also from webpack.config.js)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dolittle/boilerplates.bounded-context.csharp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Standard bounded context boilerPlates",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Removing the babel-polyfil import seemed to fix the boilerplates for me.
(I used yarn install => node run.js ) 